### PR TITLE
Slow mode update.

### DIFF
--- a/avatar.json
+++ b/avatar.json
@@ -1,6 +1,6 @@
 {
     "authors":["Tanner Limes"],
     "name": "ABC Song Player",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "color": "#78ff92"
 }


### PR DESCRIPTION
Right click song selection to enter slow mode. This greatly reduces the size and rate that pings are sent at. 
This is for cases where backend throws the "too many pings" warning. (The backend is wrong when it sends this error, I've already checked my stuff. However at busy times it seems to get confused. Slow mode reduces the chance of confusion in these situations at the cost of more buffer time for slightly-complex songs.)