### PR TITLE
V4

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ target folder
 
 Without the actual Starbound assets, you won't be able to preview your songs, but you will still be able to convert them from Midi to ABC, and you'll even be able to merge multiple tracks/files into a single ABC file. 
 
-1. Select all tracks.
-  - Ignore track 10, it's allways percussion.
+1. Select all tracks. (Deselect track 10, it's allways percussion.)
 2. Click the blue merge button.
-3. Delete the old tracks. 
-4. Save the new merged track to abc. 
+3. Delete the old tracks.
+4. Save the new merged track to abc.
+5. If you have a percussion track, save it as a seperate file, and append ` - Drums` to the end of the filename (immediatly before the `.abc` file extension). (Include the leading space in ` - Drums`.)
 
 If SBC won't work for you, you can try your hand at [this mega list of software for ABC files](https://abcnotation.com/software), some of them say they can convert ABC files to and from Midi files, however a lot of them just point to dead links. I haven't found one I really like yet. Your mileage may vary. <!-- However, [MidiZyx2abc](http://www.midicond.de/Freeware/index_en.html#MidiZyx2abc) might be pretty reasonable? -->
 
@@ -131,6 +131,7 @@ The text window for this button displays some important info:
 - Left click a queued song to start playing it.
 - Left click on a queued song while another song is playing to stop the currently playing song.
   - (This also works if the queued song is also the playing song.)
+- Right click when not playing a song to enter Slow Mode. The script is tuned to stay under the ping limit at all times. But there are several cases where the actual ping limit is lower than expected. Slow Mode significantly reduces ping size and ping rate to stay under more restrictive ping limits. 
 
 ## FAQ
 

--- a/avatar.json
+++ b/avatar.json
@@ -1,6 +1,6 @@
 {
     "authors":["Tanner Limes"],
     "name": "ABC Song Player",
-    "version": "3.0.1",
+    "version": "4.0.0",
     "color": "#78ff92"
 }

--- a/scripts/abc_player/abc_player.lua
+++ b/scripts/abc_player/abc_player.lua
@@ -1843,7 +1843,8 @@ local function queue_song_render_loop()
 	-- freeze up (though it won't crash). 
 	-- Render events are happy to drop frames, so they lock up a little less. 
 	-- WORLD_RENDER events are basicly guarrentied to be running, unlike 
-	-- player's render event
+	-- player's render event. And since this function is only called by the host,
+	-- (who we assume to have max trust) we shouldn't have any issues. 
 
 	if not songbook.song_instructions then
 		songbook.song_instructions = song_data_to_instructions(songbook.queued_song.path)

--- a/scripts/abc_player/abc_player.lua
+++ b/scripts/abc_player/abc_player.lua
@@ -927,35 +927,54 @@ local function save_abc_note_to_instructions(song)
 	return end_time
 end
 
+local data_to_instructions_song = {}
 local function song_data_to_instructions(song_abc_data_string, instrument_index)
 	-- Converts a the song.abc file into instructions we can send through pings
-	local song = {}
 
-	song.instructions = {}
+	local song = data_to_instructions_song
 
-	song.songbuilder = {}
-	song.songbuilder.abc_lines = {}
-	song.songbuilder.next_note_start_time = 0
-	song.songbuilder.key_signature_key = "C"
-	song.songbuilder.default_note_length = 0.25
-	song.songbuilder.length_of_beat_in_measure = 0.25
-	song.songbuilder.notes_per_measure = 4
-	song.songbuilder.beats_per_minute = 120
-	song.songbuilder.last_processed_note_index = 1
-	song.songbuilder.in_note_group = false
-	song.songbuilder.group_earliest_stop_time = math.huge
-	song.songbuilder.accidentals_memory = {}
-	song.songbuilder.instrument_index = instrument_index
-	song.songbuilder.note_builder = {
-	  	accidentals = "",
-	  	letter = "",
-	  	octave_ajustments = "",
-	  	duration_multiplier = "",
-	  	duration_divisor = "",
-	  	start_time = song.next_note_start_time
-	}
+	if 		not song 
+		or 	not song.songbuilder 
+		or	not song.songbuilder.in_progress 
+	then
+		-- If song or songbuilder do not exist, or if it does but not in_progress,
+		-- Then let's start a new song!
+		song = {}
+		song.instructions = {}
 
-	for line in song_abc_data_string:gmatch("[^\n]+") do
+		song.songbuilder = {}
+		song.songbuilder.abc_lines = {}
+		song.songbuilder.next_note_start_time = 0
+		song.songbuilder.key_signature_key = "C"
+		song.songbuilder.default_note_length = 0.25
+		song.songbuilder.length_of_beat_in_measure = 0.25
+		song.songbuilder.notes_per_measure = 4
+		song.songbuilder.beats_per_minute = 120
+		song.songbuilder.last_processed_note_index = 1
+		song.songbuilder.in_note_group = false
+		song.songbuilder.group_earliest_stop_time = math.huge
+		song.songbuilder.accidentals_memory = {}
+		song.songbuilder.instrument_index = instrument_index
+		song.songbuilder.note_builder = {
+			accidentals = "",
+			letter = "",
+			octave_ajustments = "",
+			duration_multiplier = "",
+			duration_divisor = "",
+			start_time = song.next_note_start_time
+		}
+
+		song.songbuilder.next_line_index = 1	-- Meta. Tracks how many lines we've done already. 
+		song.songbuilder.in_progress = false
+
+		for line in song_abc_data_string:gmatch("[^\n]+") do
+			table.insert(song.songbuilder.abc_lines, line)
+		end
+	end
+
+	print(#song.songbuilder.abc_lines)
+
+	for i, line in ipairs(song.songbuilder.abc_lines) do
 		line = line:match("(.*)%%") or line
 			-- % marks the rest of the line is a comment. Remove it and the
 			-- comment from the line. (`%%` to escape the %)

--- a/scripts/abc_player/abc_player.lua
+++ b/scripts/abc_player/abc_player.lua
@@ -171,7 +171,10 @@ local function get_song_list()
 
 				song_list[key] = nil
 			else
-				-- failed to find the base song. 
+				-- failed to find the base song, but this song fit the search pattern. 
+				-- Set this song instrument to drums anyways
+				song.full_paths[2] = song.full_paths[1]
+				song.full_paths[1] = nil
 				song.display_path = song.display_path .. " §6⚠§r"
 			end
 		end

--- a/scripts/abc_player/abc_player.lua
+++ b/scripts/abc_player/abc_player.lua
@@ -442,7 +442,13 @@ local key_signatures = {
 }
 
 -- song builder: notes to instructions -----------------------------------------
-local function save_abc_note_to_instructions(song)	-- returns note's end time
+local function save_abc_note_to_instructions(song)
+
+	-- !! Returns the end time of the note. !!
+
+	-- Converts a single note into an instruction
+	-- single note is stored in the notebuilder table. 
+
 	note_builder = song.songbuilder.note_builder
 	if note_builder.letter == "" then return note_builder.start_time end
 	--print("Saving note to instruction:")
@@ -598,6 +604,7 @@ local function save_abc_note_to_instructions(song)	-- returns note's end time
 end
 
 local function song_data_to_instructions(song_abc_data_string)
+	-- Converts a the song.abc file into instructions we can send through pings
 	local song = {}
 
 	song.instructions = {}

--- a/scripts/abc_player/abc_player.lua
+++ b/scripts/abc_player/abc_player.lua
@@ -175,7 +175,7 @@ local function get_song_list()
 				-- Set this song instrument to drums anyways
 				song.full_paths[2] = song.full_paths[1]
 				song.full_paths[1] = nil
-				song.display_path = song.display_path .. " §6⚠§r"
+				song.display_path = song.display_path .. " §7🥁?§r"
 			end
 		end
 	end

--- a/scripts/abc_player/abc_player.lua
+++ b/scripts/abc_player/abc_player.lua
@@ -1001,7 +1001,6 @@ local function song_data_to_instructions(song_file_metadata)
 	while song.songbuilder_metadata.in_progress 
 		-- and (while_loop_start_time > client.getSystemTime() -5000) 
 	do
-		-- print("loop")
 		if     -- there are notes to parse
 				song.songbuilder_metadata.notes_in_current_line
 			and #song.songbuilder_metadata.notes_in_current_line >= song.songbuilder_metadata.next_note_in_line_index
@@ -1870,10 +1869,13 @@ local function queue_song(song_files)
 	songbook.queued_packets = nil
 	songbook.queued_song.buffer_time = nil
 	songbook.queued_song.path = song_files
-	songbook.queue_song_tick_loop_is_running = true
 	
-	songbook_action_wheel_page_update_song_picker_button()
-	events.TICK:register(queue_song_tick_loop, queue_song_tick_loop_name)
+	if song_files then
+		-- if we send a nil to queue_song, we can cancel the queue. Not that we'd need to, but could be nice. 
+		songbook.queue_song_tick_loop_is_running = true
+		songbook_action_wheel_page_update_song_picker_button()
+		events.TICK:register(queue_song_tick_loop, queue_song_tick_loop_name)
+	end
 end
 
 local function play_song(song_files)

--- a/scripts/abc_player/abc_player.lua
+++ b/scripts/abc_player/abc_player.lua
@@ -417,7 +417,7 @@ local drumkitSoundsTable = {
 	-- use with drumkitSoundLookup()
 	-- keys are midi codes. see https://zendrum.com/resource-site/drumnotes.htm
 
-	-- semi-incomplete
+	-- Missing sounds default to a hat sound in drumkitSoundLookup()
 
 	[35] = function() -- Acoustic Bass Drum	
 		return sounds["block.note_block.basedrum"]:pitch(0.7)

--- a/scripts/abc_player/abc_player.lua
+++ b/scripts/abc_player/abc_player.lua
@@ -1204,9 +1204,10 @@ function deserialize(packet_string)
 			local song_instruction = {}
 			song_instruction.start_time,
 				song_instruction.end_time,
+				song_instruction.instrument_index,
 				song_instruction.semitones_from_a4,
 				song_instruction.chloe_piano
-				= serialized_instruction:match("s([^%a]+)e([^%a]+)t(%-?[^%a]+)p(%a#?%d)")
+				= serialized_instruction:match("s([^%a]+)e([^%a]+)i([^%a]+)t(%-?[^%a]+)p(%a#?%d)")
 
 			song_instruction.start_time = tonumber(song_instruction.start_time)
 			song_instruction.end_time = tonumber(song_instruction.end_time)
@@ -1216,9 +1217,10 @@ function deserialize(packet_string)
 			table.insert(songbook.incoming_song.instructions, song_instruction)
 
 			if not song_instruction or song_instruction == {} or not song_instruction.start_time then
+				print("Malformed instruction packet!")
 				printTable(song_instruction)
 				print(serialized_instruction)
-				error("soups")
+				error("Malformed instruction packet: `" .. serialized_instruction .."`")
 			end
 
 		end
@@ -1331,6 +1333,7 @@ local function song_instructions_to_packets(song_file_path, song_instructions)
 		local serialized_instruction =
 			  "s"..( string.format("%0d",instruction.start_time) )	-- D drops the decimal place, which is fine since we are allready timing everything in miliseconds. We don't need 11 digets of sub-milisecond presision
 			.."e"..( string.format("%0d",instruction.end_time) )
+			.."i"..( string.format("%0d", 1 ) )	-- TODO: instruction.instrument_index 
 			.."t"..( string.format("%0d",instruction.semitones_from_a4) )
 			.."p"..( instruction.chloe_piano and instruction.chloe_piano or "X0" )		-- Piano commands might be nil if out of range. Replace with X.
 		-- if instruction.chloe_piano == nil then print(serialized_instruction) end

--- a/scripts/abc_player/abc_player.lua
+++ b/scripts/abc_player/abc_player.lua
@@ -431,8 +431,8 @@ local drumkitSoundsTable = {
 	[38] = function() -- Acoustic Snare
 		return sounds["block.note_block.snare"]:pitch(0.7)
 	end,
-	[39] = function() -- Hand Clap
-		return sounds["block.note_block.hat"]:pitch(1)
+	[39] = function() -- Hand Clap		
+		return sounds[ "item.trident.riptide_1" ]:pitch(6 )
 	end,
 	[40] = function() -- Electric snare
 		return sounds["block.note_block.snare"]:pitch(0.8)
@@ -441,19 +441,19 @@ local drumkitSoundsTable = {
 		return sounds["block.note_block.basedrum"]:pitch(1.25)
 	end,
 	[42] = function() -- Closed Hi-Hat
-		return sounds[ "block.note_block.hat" ]:pitch(4)
+		return sounds[ "entity.player.hurt_on_fire" ]:pitch(10 )
 	end,
 	[43] = function() -- High Floor Tom
 		return sounds["block.note_block.basedrum"]:pitch(1.3)
 	end,
 	[44] = function() -- Pedal Hi-Hat
-		return sounds[ "item.trident.riptide_1" ]:pitch(6 )
+		return sounds[ "item.trident.hit_ground" ]:pitch(6 )
 	end,
 	[45] = function() -- Low Tom
 		return sounds["block.note_block.basedrum"]:pitch(1.35)
 	end,
 	[46] = function() -- Open Hi-Hat
-		return sounds[ "item.trident.hit_ground" ]:pitch(6 )
+		return sounds[ "block.fire.extinguish" ]:pitch(16)
 	end,
 	[47] = function() -- Low-Mid Tom
 		return sounds["block.note_block.basedrum"]:pitch(1.4)
@@ -535,7 +535,7 @@ local drumkitSoundsTable = {
 	-- 	return sounds["block.note_block.snare"]:pitch(0.8)
 	-- end,
 	[73] = function() -- Short Guiro
-		return sounds["entity.item.break"]:pitch(1.9)
+		return sounds["entity.player.burp"]:pitch(7)
 	end,
 	[74] = function() -- Long Guiro
 		return sounds["block.sculk_sensor.clicking"]:pitch(3)	-- has variations

--- a/scripts/abc_player/abc_player.lua
+++ b/scripts/abc_player/abc_player.lua
@@ -420,7 +420,7 @@ local drumkitSoundsTable = {
 	-- semi-incomplete
 
 	[35] = function() -- Acoustic Bass Drum	
-		return sounds["block.note_block.basedrum"]:pitch(0.5)
+		return sounds["block.note_block.basedrum"]:pitch(0.7)
 	end,
 	[36] = function() -- Bass Drum 1
 		return sounds["block.note_block.basedrum"]:pitch(0.8)
@@ -467,20 +467,20 @@ local drumkitSoundsTable = {
 	[50] = function() -- High Tom
 		return sounds["block.note_block.basedrum"]:pitch(1.5)
 	end,
-	[51] = function() -- Ride Cymbal
-		return sounds[ "item.trident.throw" ]:pitch(3)			-- has variations
+	[51] = function() -- Ride Cymbal 1
+		return sounds[ "block.bell.use" ]:pitch(4)			-- has variations
 	end,
 	[52] = function()	-- Chinese Cymbal
-		return sounds[ "item.trident.throw" ]:pitch(3.2)		-- has variations
+		return sounds[ "block.bell.use" ]:pitch(5)		-- has variations
 	end,
 	[53] = function() -- Ride Bell
-		return sounds[ "block.end_portal_frame.fill" ]:pitch(2.9)
+		return sounds[ "block.bell.use" ]:pitch(3)	-- has variations
 	end,
 	[54] = function() --Tambourine
 		return sounds[ "block.beehive.shear" ]:pitch(3.2 )
 	end,
 	[55] = function() -- Splash Cymbal
-		return sounds[ "item.trident.throw" ]:pitch(3.5)		-- has variations
+		return sounds[ "block.bell.use" ]:pitch(6)		-- has variations
 	end,
 	[56] = function() -- Cowbell
 		return sounds[ "block.note_block.cow_bell" ]:pitch(1.1)
@@ -492,8 +492,8 @@ local drumkitSoundsTable = {
 	[58] = function() -- Vibroslap
 		return sounds[ "entity.arrow.hit" ]:pitch(1.6)		-- has variations
 	end,
-	[59] = function() -- Ride Cymbal
-		return sounds[ "item.trident.throw" ]:pitch(1.65)	-- has variations
+	[59] = function() -- Ride Cymbal 2
+		return sounds[ "block.bell.use" ]:pitch(4.5)	-- has variations
 	end,
 	[60] = function() -- High Bongo
 		return sounds["entity.iron_golem.step"]:pitch(6)	-- has variations

--- a/scripts/abc_player/abc_player.lua
+++ b/scripts/abc_player/abc_player.lua
@@ -691,10 +691,10 @@ local function save_abc_note_to_instructions(song)
 
 	-- Calculate note duration
 	local time_multiplier = 1.0
-	if note_builder.durration_multiplier ~= "" then
-		time_multiplier = tonumber(note_builder.durration_multiplier)
+	if note_builder.duration_multiplier ~= "" then
+		time_multiplier = tonumber(note_builder.duration_multiplier)
 	end
-	if note_builder.durration_divisor ~= "" then
+	if note_builder.duration_divisor ~= "" then
 		-- divisor should always have at least 1 slash.
 		-- each slash means divide by two, but if there are numbers after
 		-- the slash, don't do the shorthand. A goofy workaround:
@@ -702,16 +702,16 @@ local function save_abc_note_to_instructions(song)
 		-- slash. It will cancel out the shorthand, without making us test
 		-- if we should use the shorthand
 		local numbers, num_devisions =
-			note_builder.durration_divisor:gsub("/", "")
+			note_builder.duration_divisor:gsub("/", "")
 		time_multiplier = time_multiplier / (2.0^num_devisions)
 		if numbers ~= "" then
 			time_multiplier = (time_multiplier*2.0) / tonumber(numbers)
 		end
 	end
 
-	local note_durration = song.songbuilder.time_per_note * time_multiplier
+	local note_duration = song.songbuilder.time_per_note * time_multiplier
 
-	local end_time = note_builder.start_time + note_durration
+	local end_time = note_builder.start_time + note_duration
 
 	-- Generate some strings to use in keys and print statements
 	local accidentals_memory_key = note_builder.letter
@@ -719,8 +719,8 @@ local function save_abc_note_to_instructions(song)
 	local note_string = note_builder.accidentals
 		.. note_builder.letter
 		.. note_builder.octave_ajustments
-		.. note_builder.durration_multiplier
-		.. note_builder.durration_divisor
+		.. note_builder.duration_multiplier
+		.. note_builder.duration_divisor
 
 	-- Load / Save accidentals to memory / key
 	if note_builder.accidentals ~= "" then
@@ -833,7 +833,7 @@ local function save_abc_note_to_instructions(song)
 			chloe_piano = chloe_spaced_out_piano_note_code,
 			start_time = note_builder.start_time,
 			end_time = end_time,
-			durration = end_time - note_builder.start_time,
+			duration = end_time - note_builder.start_time,
 			instrument_index = song.songbuilder.instrument_index,
 		})
 	end
@@ -864,8 +864,8 @@ local function song_data_to_instructions(song_abc_data_string, instrument_index)
 	  	accidentals = "",
 	  	letter = "",
 	  	octave_ajustments = "",
-	  	durration_multiplier = "",
-	  	durration_divisor = "",
+	  	duration_multiplier = "",
+	  	duration_divisor = "",
 	  	start_time = song.next_note_start_time
 	}
 
@@ -953,8 +953,8 @@ local function song_data_to_instructions(song_abc_data_string, instrument_index)
 				  		-- this will match any letter, but should only be given
 				  		-- A, B, C, D, E, F, G, Z, or X in upper or lower case.
 				  	octave_ajustments = note:match("[,']+") or "",
-				  	durration_multiplier = note:match("[%a,'](%d+)") or "",
-				  	durration_divisor = note:match("/+%d*") or "",
+				  	duration_multiplier = note:match("[%a,'](%d+)") or "",
+				  	duration_divisor = note:match("/+%d*") or "",
 				  		-- divisor also includes the `/` characters.
 				  	start_time = song.songbuilder.next_note_start_time
 				}
@@ -1449,15 +1449,15 @@ function deserialize(packet_string)
 		for serialized_instruction in packet_string:gmatch("[^%s]*") do	-- splits on space
 			local song_instruction = {}
 			song_instruction.start_time,
-				song_instruction.durration,
+				song_instruction.duration,
 				song_instruction.instrument_index,
 				song_instruction.semitones_from_a4,
 				song_instruction.chloe_piano
 				= serialized_instruction:match("s([^%a]+)d([^%a]+)i([^%a]+)t(%-?[^%a]+)p(%a#?%d)")
 
 			song_instruction.start_time = tonumber(song_instruction.start_time)
-			song_instruction.durration = tonumber(song_instruction.durration)
-			song_instruction.end_time = song_instruction.start_time + song_instruction.durration
+			song_instruction.duration = tonumber(song_instruction.duration)
+			song_instruction.end_time = song_instruction.start_time + song_instruction.duration
 			song_instruction.instrument_index = tonumber(song_instruction.instrument_index)
 			song_instruction.semitones_from_a4 = tonumber(song_instruction.semitones_from_a4)
 
@@ -1580,7 +1580,7 @@ local function song_instructions_to_packets(song_files, song_instructions)
 
 		local serialized_instruction =
 			  "s"..( string.format("%0d",instruction.start_time) )	-- D drops the decimal place, which is fine since we are allready timing everything in miliseconds. We don't need 11 digets of sub-milisecond presision
-			.."d"..( string.format("%0d",instruction.durration) )
+			.."d"..( string.format("%0d",instruction.duration) )
 			.."i"..( string.format("%0d",instruction.instrument_index) )
 			.."t"..( string.format("%0d",instruction.semitones_from_a4) )
 			.."p"..( instruction.chloe_piano and instruction.chloe_piano or "X0" )		-- Piano commands might be nil if out of range. Replace with X.

--- a/scripts/abc_player/abc_player.lua
+++ b/scripts/abc_player/abc_player.lua
@@ -1,5 +1,5 @@
 -- Tanner Limes was here.
--- ABC Music Player V3.0.1
+-- ABC Music Player V4.0.0
 
 -- ABC Documentation website: https://abcnotation.com/wiki/abc:standard:v2.1
 

--- a/scripts/abc_player/abc_player.lua
+++ b/scripts/abc_player/abc_player.lua
@@ -412,6 +412,170 @@ local function getPianoPos()
 	return vec(songbook.selected_chloe_piano_pos:match("{(-?%d*), (-?%d*), (-?%d*)}"))
 end
 
+local drumkitSoundsTable = {
+	-- Table of functions that return a sound, so that we'll get a fresh sound every time. 
+	-- use with drumkitSoundLookup()
+	-- keys are midi codes. see https://zendrum.com/resource-site/drumnotes.htm
+
+	-- semi-incomplete
+
+	[35] = function() -- Acoustic Bass Drum	
+		return sounds["block.note_block.basedrum"]:pitch(0.5)
+	end,
+	[36] = function() -- Bass Drum 1
+		return sounds["block.note_block.basedrum"]:pitch(0.8)
+	end,
+	[37] = function() -- Side Stick
+		return sounds["block.note_block.hat"]:pitch(0.8)
+	end,
+	[38] = function() -- Acoustic Snare
+		return sounds["block.note_block.snare"]:pitch(0.7)
+	end,
+	[39] = function() -- Hand Clap
+		return sounds["block.note_block.hat"]:pitch(1)
+	end,
+	[40] = function() -- Electric snare
+		return sounds["block.note_block.snare"]:pitch(0.8)
+	end,
+	[41] = function() -- Low Floor Tom
+		return sounds["block.note_block.basedrum"]:pitch(1.25)
+	end,
+	[42] = function() -- Closed Hi-Hat
+		return sounds[ "block.note_block.hat" ]:pitch(4)
+	end,
+	[43] = function() -- High Floor Tom
+		return sounds["block.note_block.basedrum"]:pitch(1.3)
+	end,
+	[44] = function() -- Pedal Hi-Hat
+		return sounds[ "item.trident.riptide_1" ]:pitch(6 )
+	end,
+	[45] = function() -- Low Tom
+		return sounds["block.note_block.basedrum"]:pitch(1.35)
+	end,
+	[46] = function() -- Open Hi-Hat
+		return sounds[ "item.trident.hit_ground" ]:pitch(6 )
+	end,
+	[47] = function() -- Low-Mid Tom
+		return sounds["block.note_block.basedrum"]:pitch(1.4)
+	end,
+	[48] = function() -- High-Mid Tom
+		return sounds["block.note_block.basedrum"]:pitch(1.45)
+	end,
+	[49] = function() -- Crash Cymbal 1
+		return sounds["item.trident.hit_ground"]:pitch(2)		-- has variations
+	end,
+	[50] = function() -- High Tom
+		return sounds["block.note_block.basedrum"]:pitch(1.5)
+	end,
+	[51] = function() -- Ride Cymbal
+		return sounds[ "item.trident.throw" ]:pitch(3)			-- has variations
+	end,
+	[52] = function()	-- Chinese Cymbal
+		return sounds[ "item.trident.throw" ]:pitch(3.2)		-- has variations
+	end,
+	[53] = function() -- Ride Bell
+		return sounds[ "block.end_portal_frame.fill" ]:pitch(2.9)
+	end,
+	[54] = function() --Tambourine
+		return sounds[ "block.beehive.shear" ]:pitch(3.2 )
+	end,
+	[55] = function() -- Splash Cymbal
+		return sounds[ "item.trident.throw" ]:pitch(3.5)		-- has variations
+	end,
+	[56] = function() -- Cowbell
+		return sounds[ "block.note_block.cow_bell" ]:pitch(1.1)
+	end,
+	[57] = function() -- Crash Cymbal 2
+		-- SBC's Crash 2 is nearly identical to Crash 1
+		return sounds["item.trident.hit_ground"]:pitch(2)	-- has variations
+	end,
+	[58] = function() -- Vibroslap
+		return sounds[ "entity.arrow.hit" ]:pitch(1.6)		-- has variations
+	end,
+	[59] = function() -- Ride Cymbal
+		return sounds[ "item.trident.throw" ]:pitch(1.65)	-- has variations
+	end,
+	[60] = function() -- High Bongo
+		return sounds["entity.iron_golem.step"]:pitch(6)	-- has variations
+	end,
+	[61] = function() -- Low Bongo
+		return sounds["entity.iron_golem.step"]:pitch(4)	-- has variations
+	end,
+	-- [62] = function() -- Muted High Conga
+	-- 	return sounds["block.note_block.snare"]:pitch(0.8)
+	-- end,
+	-- [63] = function() -- High Conga
+	-- 	return sounds["block.note_block.snare"]:pitch(0.8)
+	-- end,
+	-- [64] = function() -- Low Conga
+	-- 	return sounds["block.note_block.snare"]:pitch(0.8)
+	-- end,
+	-- [65] = function() -- High Timbale
+	-- 	return sounds["block.note_block.snare"]:pitch(0.8)
+	-- end,
+	-- [66] = function() -- Low Timbale
+	-- 	return sounds["block.note_block.snare"]:pitch(0.8)
+	-- end,
+	[67] = function() -- High Agogo
+		return sounds[ "entity.arrow.hit_player" ]:pitch(1.9)
+	end,
+	[68] = function() -- Low Agogo
+		return sounds[ "entity.arrow.hit_player" ]:pitch(1.7)
+	end,
+	[69] = function() -- Cabasa
+		return sounds[ "entity.silverfish.death" ]:pitch(4)
+	end,
+	[70] = function() -- Maracas
+		return sounds[ "entity.iron_golem.attack" ]:pitch(3)
+	end,
+	-- [71] = function() -- Short Whistle
+	-- 	return sounds["block.note_block.snare"]:pitch(0.8)
+	-- end,
+	-- [72] = function() -- Long Whistle
+	-- 	return sounds["block.note_block.snare"]:pitch(0.8)
+	-- end,
+	[73] = function() -- Short Guiro
+		return sounds["entity.item.break"]:pitch(1.9)
+	end,
+	[74] = function() -- Long Guiro
+		return sounds["block.sculk_sensor.clicking"]:pitch(3)	-- has variations
+	end,
+	-- [75] = function() -- Claves
+	-- 	return sounds["block.note_block.snare"]:pitch(0.8)
+	-- end,
+	-- [76] = function() -- High Wood Block
+	-- 	return sounds["block.note_block.snare"]:pitch(0.8)
+	-- end,
+	-- [77] = function() -- Low Wood Block
+	-- 	return sounds["block.note_block.snare"]:pitch(0.8)
+	-- end,
+	-- [78] = function() -- Muted Cuica
+	-- 	return sounds["block.note_block.snare"]:pitch(0.8)
+	-- end,
+	-- [79] = function() -- Open Cuica
+	-- 	return sounds["block.note_block.snare"]:pitch(0.8)
+	-- end,
+	-- [80] = function() -- Mute Triangle
+	-- 	return sounds["block.note_block.snare"]:pitch(0.8)
+	-- end,
+	-- [81] = function() -- Open triangle
+	-- 	return sounds["block.note_block.snare"]:pitch(0.8)
+	-- end,
+}
+
+local function drumkitSoundLookup(semitones_from_a4)
+	local midi_key = semitones_from_a4 + 69	-- A4 is midi key 69. nice. 
+		-- 35 == B1, but SBC calls this B2 for some reason :/
+		-- Whatever. It works, and my ABC parcing is (probably) correct. 
+	if drumkitSoundsTable[midi_key] then
+		return drumkitSoundsTable[midi_key]()
+	end
+
+	return sounds["minecraft:block.note_block.hat"]:setPitch(
+			semitone_offset_to_multiplier(semitones_from_a4+3-12 +24)
+		)
+end
+
 local function fracToNumber(str)
 	local top, bot = str:match("(%d)/(%d)")
 	--print(str.." > "..top.." / "..bot)
@@ -866,10 +1030,10 @@ function play_song_event_loop()
 				.."/"..#song.instructions
 				.."/"..song.num_expected_instructions
 				.." ".. instruction.chloe_piano .. (#instruction.chloe_piano > 2 and "" or " ")
+				-- .." ".. instruction.semitones_from_a4
 
 			)	-- ` #20/100/2000 A4 `
-			if isUsingPiano()
-				and instruction.instrument_index == 1	-- main instrument only
+			if isUsingPiano() and instruction.instrument_index == 1	-- main instrument only
 			then
 				-- Catches if the piano was broken recently.
 			 	-- print("playing note "..instruction.chloe_piano.. " on piano at "..songbook.selected_chloe_piano_pos)
@@ -881,15 +1045,11 @@ function play_song_event_loop()
 			 	-- checking if the note's done playing.
 			else
 				if instruction.instrument_index == 2 then
-					instruction.sound_id = sounds["minecraft:block.note_block.hat"]
+					instruction.sound_id = drumkitSoundLookup(instruction.semitones_from_a4)
 						:setVolume( isUsingPiano() and 0.8 or 0.5)
-						:setPitch(
-							-- TODO: Set sound based on pitch instead of actualy pitching the percussion sound. 
-							-- create lookup table to go from semitones_from_a4 to sound+pitch combo. 
-							semitone_offset_to_multiplier(instruction.semitones_from_a4)
-						)
 				elseif avatar:canUseCustomSounds() then
 					instruction.sound_id = sounds["scripts.abc_player.triangle_sin"]
+						:setVolume(4)
 						:setLoop(true)
 						:setPitch(
 							semitone_offset_to_multiplier(instruction.semitones_from_a4)

--- a/scripts/abc_player/abc_player.lua
+++ b/scripts/abc_player/abc_player.lua
@@ -93,9 +93,14 @@ local function get_song_list()
 	local song_list = {}
 	--	song_list = { 
 	--		1: {
-	--			name, 			-- string. Short name of file. Excludes path and `.abc`
-	--			display_path	-- string. Path excluding `songbook_root_file_path`
-	--			safe_path		-- string. Full path for filesAPI
+	--			name, 			-- string. Short name of file. Excludes path and `.abc`		-- used in display board
+	--			display_path	-- string. Path excluding `songbook_root_file_path`			-- used in song picker
+	--			full_paths: {	-- table of strings. Set of full paths for files API
+	--				1: "Path to main instrument"
+	--				2: "Path to percussion track" (if available)
+	--				3: "path to 3rd instrument track"	(May never be used.)
+	--				-- full_path index represents the instrument to use to play the file. Must be an int. 
+	--			}		
 	-- 		},
 	-- 		2: { etc… },
 	--		…
@@ -122,7 +127,7 @@ local function get_song_list()
 				table.insert(song_list, #song_list +1, {
 					name = current_path:match("([^/]*)%."), -- everything after last / and before last .
 					display_path = current_path,
-					safe_path = full_path
+					full_paths = {full_path}
 				}
 			);
 			end
@@ -134,6 +139,11 @@ local function get_song_list()
 	if #song_list < 1 then 
 		print("No songs found. Add `.abc` song files to `[figura_root]/data/"..songbook_root_file_path.."`. Then reload the avatar.")
 	end
+
+	-- Rescan final list to merge sings with recognized tracks keys like "drums"
+
+
+
 	return song_list
 end
 
@@ -1371,13 +1381,13 @@ local function queue_song(song_file_path)
 	
 	-- print("Preparing to play "..song_file_path.name)
 
-	if not file:isFile(song_file_path.safe_path) then 
-		print("No file found at `".. song_file_path.safe_path .."`.")
+	if not file:isFile(song_file_path.full_paths[1]) then 
+		print("No file found at `".. song_file_path.full_paths[1] .."`.")
 		return 
 	end
 
 	-- TODO: validation. Make sure incomming file looks like an ABC file?
-	local song_abc_data = file:readString(song_file_path.safe_path)
+	local song_abc_data = file:readString(song_file_path.full_paths[1])
 
 	-- Convert data to instructions.
 	--print("Generating instructions...")

--- a/scripts/abc_player/abc_player.lua
+++ b/scripts/abc_player/abc_player.lua
@@ -1305,16 +1305,15 @@ end
 
 -- Display info ----------------------------------------------------------------
 local spinner_states = {[1] = "▙",[2] = "▛",[3] = "▜",[4] = "▟",}
-local last_spinner_state = 1
-local spinner_delay_counter = 1
-local spinner_delay_counter_max = 5
 local function info_display_spinner()
-	if spinner_delay_counter > spinner_delay_counter_max then
-		last_spinner_state = (last_spinner_state+1) % #spinner_states
-		spinner_delay_counter = 1
-	end
-	spinner_delay_counter = spinner_delay_counter + 1
-	return spinner_states[last_spinner_state+1]
+	local spinner_State = 
+		math.floor(
+			(client.getSystemTime()/1000)	-- Time in Seconds
+			*1.5	-- Speedup
+			%1		-- Clamp to 0-1
+			*4		-- Scale to 0-3
+		)+1			-- Scale to 1-4
+	return spinner_states[spinner_State]
 end
 
 local function progress_bar(width, progress)

--- a/scripts/abc_player/abc_player.lua
+++ b/scripts/abc_player/abc_player.lua
@@ -649,16 +649,6 @@ local letter_to_semitone_offsets = {
 	["C"] = -9,
 }
 
-local chloe_piano_flat_to_sharp_table = {
-	["B"] = "A#",
-	["A"] = "G#",
-	["G"] = "F#",
-	["F"] = "E",
-	["E"] = "D#",
-	["D"] = "C#",
-	["C"] = "B",	-- << Special case: downgrade octave number.
-}
-
 local key_signatures_keys = {
 	["7#"] = {"C#", "A#M", "G#MIX", "D#DOR", "E#PHR", "F#LYD", "B#LOC"},
 	["6#"] = {"F#", "D#M", "C#MIX", "G#DOR", "A#PHR", "BLYD",  "E#LOC"},


### PR DESCRIPTION
Version 4!

- **Drum tracks**. A song named `example - Drums.abc` will play with a drum kit instead of the base instrument.
   - This uses the same drum kit layout as Midi, so you can convert directly from Midi to ABC and it should™ work. 
   - If `example.abc` also exists, `example - Drums.abc` will be merged into it and **both will play together**. 
- The script is now smarter about packet generation, resulting in **fewer pings**, and **faster buffer times**. 
- Generating song instructions now happens over time. Previously, very big songs would freeze the game and cause the client to time out. Even on single player. Now the script will give control back to the game in these cases, **preventing timeout errors**. (Rush E is now playable again.) 